### PR TITLE
fix: skip refresh after the editor view is destroyed

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -84,7 +84,7 @@ export function createHighlightPlugin({
 
       // Refresh the decorations when all promises resolve
       const refresh = () => {
-        if (promises.size > 0) {
+        if (promises.size > 0 || view.isDestroyed) {
           return
         }
         const tr = view.state.tr.setMeta('prosemirror-highlight-refresh', true)

--- a/test/destroyed-view.spec.ts
+++ b/test/destroyed-view.spec.ts
@@ -1,0 +1,47 @@
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { schema } from '../playground/schema'
+import { createHighlightPlugin } from '../src/plugin'
+import type { Parser } from '../src/types'
+
+import { setupNodes } from './helpers'
+
+describe('createHighlightPlugin', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not refresh after the view is destroyed', async () => {
+    const errors: unknown[] = []
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      errors.push(...args)
+    })
+
+    let resolveParse: () => void = () => {}
+    const parsing = new Promise<void>((resolve) => {
+      resolveParse = resolve
+    })
+    const parser: Parser = () => parsing
+
+    const nodes = setupNodes(schema)
+    const doc = nodes.doc([nodes.codeBlock('javascript', '1 + 1')])
+    const state = EditorState.create({
+      doc,
+      plugins: [createHighlightPlugin({ parser })],
+    })
+    const view = new EditorView(document.createElement('div'), { state })
+    const dispatch = vi.spyOn(view, 'dispatch')
+
+    // The parser resolves only after the view is gone, which is what happens
+    // when an async grammar finishes loading post-unmount.
+    view.destroy()
+    resolveParse()
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+    expect(view.isDestroyed).toBe(true)
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(errors).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

When a code block's parser returns a Promise (an async/lazy highlighter loading a grammar), the plugin schedules a `refresh()` that runs `view.dispatch()` once the promise resolves. If the `EditorView` is destroyed before the grammar finishes loading, that dispatch runs against a destroyed view:

```
[prosemirror-highlight] Error resolving parser: TypeError: Cannot read properties of null (reading 'matchesNode')
    at EditorView.updateStateInner
    at EditorView.updateState
    at EditorView.dispatch
    at refresh
```

`view.destroy()` sets `view.docView = null`, and `updateStateInner` dereferences it (`this.docView.matchesNode(...)`).

This is common in development: React StrictMode double-mounts (mount → unmount → remount) and HMR/Fast Refresh re-mounts on every edit, so a grammar regularly finishes loading after its view was torn down.

## Fix

Bail out of `refresh()` when the view has already been destroyed:

```ts
const refresh = () => {
  if (promises.size > 0 || view.isDestroyed) {
    return
  }
  ...
}
```

`EditorView.isDestroyed` has been available since `prosemirror-view@1.23.0`, well within the existing `^1.32.4` peer range.

## Test

`test/destroyed-view.spec.ts` mounts a view with a pending parser promise, destroys the view, then resolves the promise, and asserts that no dispatch happens and no error is logged. It fails without the guard (`dispatch` called once) and passes with it.
