### PR TITLE
fix: allow inline nodes with inlineContent to be highlighted

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -188,7 +188,7 @@ function collectCodeBlocks(
 ): Array<[node: ProseMirrorNode, pos: number]> {
   const nodes: Array<[node: ProseMirrorNode, pos: number]> = []
   doc.descendants((node, pos) => {
-    if (node.type.isTextblock && nodeTypes.includes(node.type.name)) {
+    if (node.type.inlineContent && nodeTypes.includes(node.type.name)) {
       nodes.push([node, pos])
       return false
     }


### PR DESCRIPTION
Technically an inline node can contain inline content, I'm dealing with this with an inline math node, which is an inline node (it sits inline with text), but also contains inline content & I want for that content to be highlighted.

So, I changed the gate to be from `.isTextblock` which requires the node to both have inline content & be a block-level element https://prosemirror.net/docs/ref/#model.Node.isTextblock , to `.inlineContent` which is only when there is inlineContent to a node: https://prosemirror.net/docs/ref/#model.Node.inlineContent
