### PR TITLE
ci: skip deploy job on pull requests from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: ./.github/actions/setup
-        with:
-          node-version: ${{ matrix.node }}
 
       - name: Build
         run: pnpm run build:playground

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    # Forked repositories don't have access to the Cloudflare secrets.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       deployments: write


### PR DESCRIPTION
The `deploy` job publishes the playground to Cloudflare Pages using `CLOUDFLARE_PAGES_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. GitHub does not expose repository secrets to workflows triggered by pull requests from forks, so the job always fails there.

Skip the job when the pull request comes from a fork. On `push` events `github.event.pull_request` is null, so the condition still evaluates to true and `master` keeps deploying.